### PR TITLE
Compatible with RN 0.28+

### DIFF
--- a/BarCollapsible.js
+++ b/BarCollapsible.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { Animated, View, Text, TouchableHighlight } from 'react-native';
+import React from 'react';
+import { Animated, View, Text, TouchableHighlight } from 'react-native';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/caroaguilar/react-native-bar-collapsible#readme",
   "dependencies": {
-    "react-native-vector-icons": "^1.3.4"
+    "react-native-vector-icons": "^2.0.3"
   }
 }


### PR DESCRIPTION
Latest React Native shown error 'React.PropTypes.oneOf'. Also I update react-native-vector-icons because previously it use old version, which is not compatible with RN 0.28+ too. This PR will fix that error