### PR TITLE
Remove backgroundColor and add titleStyle for more customization

### DIFF
--- a/BarCollapsible.js
+++ b/BarCollapsible.js
@@ -63,7 +63,7 @@ class BarCollapsible extends Component {
     _renderDefault() {
         return (
             <View style={styles.bar}>
-                <Text style={styles.title}>{this.state.title}</Text>
+                <Text style={[styles.title, this.props.titleStyle]}>{this.state.title}</Text>
             </View>
         );
     }
@@ -72,7 +72,7 @@ class BarCollapsible extends Component {
         return (
             <TouchableHighlight style={styles.barWrapper} underlayColor='transparent' onPress={this.state.onPressed}>
                 <View style={[styles.bar, this.props.style]}>
-                    <Text style={styles.title}>{this.state.title}</Text>
+                    <Text style={[styles.title, this.props.titleStyle]}>{this.state.title}</Text>
                     <Icon name={this.state.icon} size={this._iconSize} color={this._tintColor} style={styles.icon}/>
                 </View>
             </TouchableHighlight>
@@ -84,7 +84,7 @@ class BarCollapsible extends Component {
             <View>
                 <TouchableHighlight style={styles.barWrapper} underlayColor='transparent' onPress={() => { this._toggleView()}}>
                     <View style={[styles.bar, this.props.style]}>
-                        <Text style={styles.title}>{this.state.title}</Text>
+                        <Text style={[styles.title, this.props.titleStyle]}>{this.state.title}</Text>
                         <Icon name={this.state.icon} size={this._iconSize} color={this._tintColor} style={styles.icon}/>
                     </View>
                 </TouchableHighlight>
@@ -106,6 +106,7 @@ class BarCollapsible extends Component {
 
 BarCollapsible.propTypes = {
   style: View.propTypes.style,
+  titleStyle: Text.propTypes.style,
   tintColor: PropTypes.string,
 };
 

--- a/BarCollapsible.js
+++ b/BarCollapsible.js
@@ -1,13 +1,13 @@
 'use strict';
 
-import React from 'react';
+import React, { PropTypes, Component } from 'react';
 import { Animated, View, Text, TouchableHighlight } from 'react-native';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import styles from './style'
 
-class BarCollapsible extends React.Component {
+class BarCollapsible extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -47,7 +47,6 @@ class BarCollapsible extends React.Component {
 
         this._tintColor = this.props.tintColor || '#FFF';
         this._iconSize = this.props.iconSize || 30;
-        this._backgroundColor = { backgroundColor: this.props.backgroundColor };
     }
 
     render() {
@@ -72,7 +71,7 @@ class BarCollapsible extends React.Component {
     _renderClickable() {
         return (
             <TouchableHighlight style={styles.barWrapper} underlayColor='transparent' onPress={this.state.onPressed}>
-                <View style={[styles.bar, this._backgroundColor]}>
+                <View style={[styles.bar, this.props.style]}>
                     <Text style={styles.title}>{this.state.title}</Text>
                     <Icon name={this.state.icon} size={this._iconSize} color={this._tintColor} style={styles.icon}/>
                 </View>
@@ -84,7 +83,7 @@ class BarCollapsible extends React.Component {
         return (
             <View>
                 <TouchableHighlight style={styles.barWrapper} underlayColor='transparent' onPress={() => { this._toggleView()}}>
-                    <View style={[styles.bar, this._backgroundColor]}>
+                    <View style={[styles.bar, this.props.style]}>
                         <Text style={styles.title}>{this.state.title}</Text>
                         <Icon name={this.state.icon} size={this._iconSize} color={this._tintColor} style={styles.icon}/>
                     </View>
@@ -104,5 +103,10 @@ class BarCollapsible extends React.Component {
         });
     }
 }
+
+BarCollapsible.propTypes = {
+  style: View.propTypes.style,
+  tintColor: PropTypes.string,
+};
 
 module.exports = BarCollapsible;

--- a/README.md
+++ b/README.md
@@ -83,24 +83,37 @@ You need to pass the properties:
     iconCollapsed='chevron-right'
     iconOpened='chevron-down'
     children={<OtherComponent/>}/>
+
+// or
+
+<Bar
+    title='My title'
+    collapsible={true}
+    iconCollapsed='chevron-right'
+    iconOpened='chevron-down'
+>
+  <OtherComponent />
+</Bar>
 ```
 
 ### Another properties for customization
 
 Additional to the basic properties, you can pass:
 
-- ***backgroundColor***
+- ***style***
 - ***iconSize***
 - ***tintColor***
+- ***titleStyle***
 
 ```jsx
 <Bar
+    style={{ backgroundColor: '#FFF'}}
     title='My title'
+    titleStyle={{ color: #000 }}
     clickable={true}
     icon='rocket'
-    backgroundColor='#BF5327'
-    tintColor='#F2F2F2'
-    iconSize={15}/>
+    tintColor='#BBB'
+    iconSize={15} />
 ```
 
 ### Icons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bar-collapsible",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "React Native bar component could be read-only, clickable or collapsible",
   "main": "BarCollapsible.js",
   "scripts": {
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/caroaguilar/react-native-bar-collapsible#readme",
   "dependencies": {
-    "react-native-vector-icons": "^2.0.3"
+    "react-native-vector-icons": "^3.0.0"
   }
 }


### PR DESCRIPTION
Remove the backgroundColor for use the style instead and add the titleStyle prop, both for more customization level

```jsx
<Bar
    style={{ backgroundColor: '#FFF'}}
    title='My title'
    titleStyle={{ color: #000 }}
    clickable={true}
    icon='rocket'
    tintColor='#BBB'
    iconSize={15} />
```