### PR TITLE
fix prop types error

### DIFF
--- a/BarCollapsible.js
+++ b/BarCollapsible.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import {ViewPropTypes} from 'react-native'
 import { 
     Animated, 
     View, 
@@ -26,7 +27,7 @@ class BarCollapsible extends Component {
     }
 
     static propTypes = {
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         titleStyle: Text.propTypes.style,
         tintColor: PropTypes.string,
     }


### PR DESCRIPTION
fix prop types error for newer react native version (ViewPropTypes instead of View.Proptypes)